### PR TITLE
Introduce the Scheme error object.

### DIFF
--- a/gscheme/error.go
+++ b/gscheme/error.go
@@ -1,0 +1,48 @@
+package gscheme
+
+import "fmt"
+
+// Error is the interface for all Scheme errors.
+// TODO(jbvoskuhl): Include the type of error so we can tell user/file/read errors apart.
+type Error interface {
+	fmt.Stringer
+	error
+	GetMessage() string
+	GetIrritants() Pair
+}
+
+// schemeError is the concrete type behind the Error interface.
+type schemeError struct {
+	message   string
+	irritants Pair
+}
+
+// NewError creates a new Error object, but does not raise a panic.
+func NewError(message string, irritants Pair) Error {
+	return &schemeError{message, irritants}
+}
+
+// GetMessage gives back the message provided when error was called.
+func (e schemeError) GetMessage() string {
+	return e.message
+}
+
+// GetIrritants returns the extra objects provided when error was called.
+func (e schemeError) GetIrritants() Pair {
+	return e.irritants
+}
+
+// Convert the error to a string including the message and irritants.
+func (e schemeError) String() string {
+	return e.message
+}
+
+// Convert the error to a string including the message and irritants.
+func (e schemeError) Error() string {
+	return e.message
+}
+
+// Err is used in gscheme to package up an error and raise it using the panic functionality.
+func Err(message string, irritants Pair) interface{} {
+	panic(NewError(message, irritants))
+}

--- a/gscheme/error_test.go
+++ b/gscheme/error_test.go
@@ -1,0 +1,39 @@
+package gscheme
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestNewError(t *testing.T) {
+	e := NewError("message", List(1, 2, 3))
+	if e.GetMessage() != "message" {
+		t.Errorf("Error message was expected to be 'message' and instead was: %v.", e.GetMessage())
+	}
+	if e.String() != "message" {
+		t.Errorf("Error as string was expected to be 'message' and instead was: %v.", e.String())
+	}
+	if e.Error() != "message" {
+		t.Errorf("Scheme error as error was expected to be 'message' and instead was: %v.", e.Error())
+	}
+	if !reflect.DeepEqual(e.GetIrritants(), List(1, 2, 3)) {
+		t.Errorf("Error irritants were expected to be (1 2 3) and instead was: %v.", e.GetIrritants())
+	}
+}
+
+func TestErr(t *testing.T) {
+	defer func() {
+		recovered := recover()
+		if recovered == nil {
+			t.Error("Expected to see a panic occur via Err.")
+		}
+		e, ok := recovered.(Error)
+		if !ok {
+			t.Errorf("Error recovered from panic was not of type Error: %v.", e)
+		}
+		if e.GetMessage() != "message" {
+			t.Errorf("Error message recovered from panic was not 'message': %v.", e.GetMessage())
+		}
+	}()
+	Err("message", nil)
+}

--- a/gscheme/pair.go
+++ b/gscheme/pair.go
@@ -77,8 +77,7 @@ func SetFirst(x interface{}, y interface{}) interface{} {
 		pair.SetFirst(y)
 		return y
 	}
-	// TODO(jbvoskuhl): Change this once Error is checked in.
-	return nil // Error("Attempt to set-car of a non-Pair:" + Stringify(x))
+	return Err("Attempt to set-car of a non-Pair:", List(y))
 }
 
 // SetRest is like Common Lisp (setf (rest x) y) and changes the cdr of x to be y.
@@ -87,8 +86,7 @@ func SetRest(x interface{}, y interface{}) interface{} {
 		pair.SetRest(y)
 		return y
 	}
-	// TODO(jbvoskuhl): Change this once Error is checked in.
-	return nil // Error("Attempt to set-cdr of a non-Pair: " + Stringify(x))
+	return Err("Attempt to set-cdr of a non-Pair: ", List(y))
 }
 
 // Second is like Common Lisp second and returns the second item in a list.
@@ -101,11 +99,11 @@ func Third(x interface{}) interface{} {
 	return First(Rest(Rest(x)))
 }
 
-func List(elements ...interface{}) interface{} {
+func List(elements ...interface{}) Pair {
 	index := len(elements) - 1
-	var result interface{} = nil
+	var result Pair = nil
 	for index >= 0 {
-		result = Cons(elements[index], result)
+		result = NewPair(elements[index], result)
 		index--
 	}
 	return result


### PR DESCRIPTION
Introduce the scheme error object which allows programs to raise exceptions and communicate error messages as well as a list of associated objects called irritants.  See R7RS 6.11.