### PR TITLE
Implement proper R7RS lazy evaluation with Promise type.

### DIFF
--- a/gscheme/primitives.go
+++ b/gscheme/primitives.go
@@ -150,24 +150,8 @@ const primitivesScheme = `
                                                               (list (cons '__loop__ steps))))))))))
             (cons '__loop__ inits)))))
 
-;; delay macro: lazy evaluation, creates a promise
-(define delay
-  (macro (exp)
-    (list 'let (list (list '__result-ready?__ #f)
-                     (list '__result__ #f))
-          (list 'lambda '()
-                (list 'if '__result-ready?__
-                      '__result__
-                      (list 'let (list (list '__x__ exp))
-                            (list 'if '__result-ready?__
-                                  '__result__
-                                  (list 'begin
-                                        (list 'set! '__result-ready?__ #t)
-                                        (list 'set! '__result__ '__x__)
-                                        '__result__))))))))
-
-;; force: evaluate a promise
-(define (force promise) (promise))
+;; delay and delay-force are special forms handled by the evaluator.
+;; force, make-promise, and promise? are Go primitives (see promise.go).
 
 ;; when: evaluate body when test is true
 (define when

--- a/gscheme/promise.go
+++ b/gscheme/promise.go
@@ -1,0 +1,89 @@
+package gscheme
+
+// promiseState holds the mutable fields of a promise, kept behind a pointer
+// so that delay-force can flatten nested promises by swapping the state pointer.
+type promiseState struct {
+	forced    bool
+	value     interface{}
+	thunk     Applyer
+	iterative bool // true for delay-force promises
+}
+
+// Promise is a lazy value created by delay, delay-force, or make-promise.
+type Promise struct {
+	state *promiseState
+}
+
+func (p *Promise) String() string {
+	return "#<promise>"
+}
+
+// installPromisePrimitives registers force, make-promise, and promise?.
+// delay and delay-force are handled as special forms in eval.
+func installPromisePrimitives(environment Environment) {
+	environment.DefineName(NewHigherOrderPrimitive("force", 1, 1, primitiveForce))
+	environment.DefineName(NewPrimitive("make-promise", 1, 1, primitiveMakePromise))
+	environment.DefineName(NewPrimitive("promise?", 1, 1, primitiveIsPromise))
+}
+
+// primitiveForce forces a promise. For non-promise values returns the value
+// unchanged (R7RS 6.4). For delay-force promises iteratively flattens nested
+// promises to preserve proper tail behaviour.
+func primitiveForce(s Scheme, args Pair, env Environment) interface{} {
+	return forceValue(s, env, First(args))
+}
+
+func forceValue(s Scheme, env Environment, x interface{}) interface{} {
+	for {
+		p, ok := x.(*Promise)
+		if !ok {
+			return x
+		}
+		if p.state.forced {
+			return p.state.value
+		}
+
+		result := p.state.thunk.Apply(s, nil, env)
+
+		// Re-raise errors from the thunk body so guard/with-exception-handler
+		// can catch them, consistent with the surrounding evaluator.
+		if err, ok := result.(Error); ok {
+			panic(err)
+		}
+
+		// Another call to force inside the thunk may have already forced us.
+		if p.state.forced {
+			return p.state.value
+		}
+
+		if p.state.iterative {
+			if inner, ok2 := result.(*Promise); ok2 {
+				// Flatten: adopt inner promise's state so this promise shares it.
+				// The next iteration will force the inner state if needed.
+				p.state = inner.state
+				continue
+			}
+		}
+
+		p.state.forced = true
+		p.state.value = result
+		p.state.thunk = nil
+		return result
+	}
+}
+
+// primitiveMakePromise wraps a value in an already-forced promise.
+// If the argument is already a promise, returns it unchanged (R7RS 6.4).
+func primitiveMakePromise(args Pair) interface{} {
+	x := First(args)
+	if p, ok := x.(*Promise); ok {
+		return p
+	}
+	return &Promise{state: &promiseState{forced: true, value: x}}
+}
+
+// primitiveIsPromise returns #t if the argument is a promise.
+func primitiveIsPromise(args Pair) interface{} {
+	_, ok := First(args).(*Promise)
+	return ok
+}

--- a/gscheme/scheme.go
+++ b/gscheme/scheme.go
@@ -46,6 +46,7 @@ func New() Scheme {
 	installPredicatePrimitives(result.environment)
 	installComplexPrimitives(result.environment)
 	installHigherOrderPrimitives(result.environment)
+	installPromisePrimitives(result.environment)
 	installStringPrimitives(result.environment)
 	installVectorPrimitives(result.environment)
 	installIOPrimitives(result.environment, result)
@@ -369,6 +370,14 @@ func (s *scheme) eval(x interface{}, environment Environment) interface{} {
 					params := First(args)
 					body := Rest(args)
 					return NewMacro(params, body, environment)
+
+				case "delay":
+					thunk := NewClosure(nil, args, environment)
+					return &Promise{state: &promiseState{thunk: thunk}}
+
+				case "delay-force", "lazy":
+					thunk := NewClosure(nil, args, environment)
+					return &Promise{state: &promiseState{thunk: thunk, iterative: true}}
 				}
 			}
 

--- a/gscheme/testdata/scheme-tests.scm
+++ b/gscheme/testdata/scheme-tests.scm
@@ -183,7 +183,7 @@
   (force p)
   (test-equal "promise memoization" 1 count)
   ;; promise is a procedure
-  (test-eqv "promise is procedure" #t (procedure? (delay 42)))
+  (test-eqv "promise? recognises delay result" #t (promise? (delay 42)))
 
   ;; body not evaluated until forced
   (define lazy-count 0)
@@ -222,27 +222,30 @@
     (guard (e (#t (error-object? e)))
       (force (delay (error "promise error")))))
 
-  ;; R7RS gaps — not currently implemented:
-  ;;
-  ;; (force non-promise) should return the value unchanged (R7RS 6.4):
-  ;;   (test-equal "force non-promise returns value" 42 (force 42))
-  ;;
-  ;; promise? predicate (R7RS 6.4):
-  ;;   (test-eqv "promise? on promise" #t (promise? (delay 1)))
-  ;;   (test-eqv "promise? on non-promise" #f (promise? 42))
-  ;;
-  ;; make-promise — wraps a plain value as an already-forced promise (R7RS 6.4):
-  ;;   (test-equal "make-promise wraps value" 5 (force (make-promise 5)))
-  ;;   (test-eqv "make-promise on promise is identity" #t
-  ;;     (let ((p (delay 1))) (eq? p (make-promise p))))
-  ;;
-  ;; delay-force (aka lazy) — for iterative lazy algorithms without stack growth (R7RS 6.4):
-  ;;   (define (lazy-stream-from n)
-  ;;     (delay-force (cons n (lazy-stream-from (+ n 1)))))
-  ;;   (test-equal "delay-force iterative" 1000
-  ;;     (car (force (let loop ((s (lazy-stream-from 0)) (n 1000))
-  ;;                   (if (= n 0) s (loop (cdr (force s)) (- n 1)))))))
-  )
+  ;; promise? predicate
+  (test-eqv "promise? on promise" #t (promise? (delay 1)))
+  (test-eqv "promise? on non-promise" #f (promise? 42))
+  ;; promise is not a procedure (R7RS distinguishes promise from procedure)
+  (test-eqv "promise is not procedure" #f (procedure? (delay 42)))
+
+  ;; (force non-promise) returns the value unchanged (R7RS 6.4)
+  (test-equal "force non-promise returns value" 42 (force 42))
+
+  ;; make-promise wraps a plain value as an already-forced promise
+  (test-equal "make-promise wraps value" 5 (force (make-promise 5)))
+  (test-eqv "make-promise on promise is identity" #t
+    (let ((p (delay 1))) (eq? p (make-promise p))))
+
+  ;; delay-force (lazy) — iterative lazy streams without stack growth
+  (define (lazy-stream-from n)
+    (delay-force (cons n (lazy-stream-from (+ n 1)))))
+  (test-equal "delay-force iterative" 1000
+    (car (force (let loop ((s (lazy-stream-from 0)) (n 1000))
+                  (if (= n 0) s (loop (cdr (force s)) (- n 1)))))))
+
+  ;; lazy is an alias for delay-force
+  (test-eqv "lazy alias for delay-force" #t
+    (promise? (lazy (values 1 2)))))
 
 (test-group "map/for-each/apply"
   (test-equal "map multi-list" '(11 22 33) (map + '(1 2 3) '(10 20 30)))


### PR DESCRIPTION
Replace the Scheme-macro-based delay/force with a dedicated Go Promise type, enabling promise?, make-promise, and delay-force to be implemented correctly.

- Add Promise type (promise.go) with force, make-promise, promise? primitives
- Add delay and delay-force/lazy as special forms in the evaluator so they capture unevaluated expressions without needing a macro
- delay-force uses iterative flattening (state-pointer swap) to support infinite lazy streams without stack growth
- force on a non-promise returns the value unchanged (R7RS 6.4)
- Remove Scheme-macro delay and force from primitives.go; they ran after installPromisePrimitives and would have shadowed the Go implementations
- Update scheme-tests.scm: fix "promise is procedure" assertion (promises are no longer closures), and enable all previously-skipped R7RS 6.4 tests including delay-force iterative stream traversal